### PR TITLE
fix: remove hard-coded paths and patch overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7940,6 +7940,8 @@ dependencies = [
 [[package]]
 name = "trueno-cuda-edge"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f8ab856a9d76851d12d0f02d09017046ac5bbb232c75c5cf00d0f7bb23ce61"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -8005,7 +8007,9 @@ dependencies = [
 
 [[package]]
 name = "trueno-rag"
-version = "0.2.2"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad9b10493d9af8befce7cf7c3db9f7bb92c9d04957cca8a543d01601345203a"
 dependencies = [
  "async-trait",
  "batuta-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ entrenar = { version = "0.7", optional = true }
 alimentar = { version = "0.2", optional = true }
 
 # RAG and visualization (native-only)
-trueno-rag = { version = "0.2", path = "../trueno-rag", features = ["sqlite"], optional = true }
+trueno-rag = { version = "0.2", features = ["sqlite"], optional = true }
 trueno-viz = { version = "0.2", optional = true }
 presentar = { version = "0.3", optional = true }
 
@@ -281,7 +281,7 @@ tempfile = "3.23"
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1.5"
 blake3 = "1.8"
-trueno-cuda-edge = { version = "0.1", path = "../trueno/trueno-cuda-edge" }
+trueno-cuda-edge = { version = "0.1" }
 
 [[bench]]
 name = "backend_selection"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1069,7 +1069,7 @@ rust_stack_dirs = ["../rmedia"]
 name = "intel"
 type = "ssh"
 host = "intel.local"
-index_path = "/home/noah/.cache/batuta/rag/index.sqlite"
+index_path = "/tmp/batuta/rag/index.sqlite"
 "#;
         let config: PrivateConfig = toml::from_str(toml_str).expect("toml parse failed");
         assert_eq!(config.private.endpoints.len(), 1);


### PR DESCRIPTION
## Summary

- Remove `path = "../trueno-rag"` local path override from `trueno-rag` dependency (now resolves from crates.io v0.2.4)
- Remove `path = "../trueno/trueno-cuda-edge"` local path override from `trueno-cuda-edge` dev-dependency (now resolves from crates.io v0.1.0)
- Replace hard-coded `/home/noah/.cache/batuta/rag/index.sqlite` with `/tmp/batuta/rag/index.sqlite` in test fixture in `src/config.rs`

These local path overrides break clean-room CI builds where sibling repos are not present on the runner filesystem.

## Test plan

- [x] `cargo check` passes after removing path overrides (resolves from crates.io)
- [x] No remaining `/home/noah` or `/mnt/nvme-raid0` paths in `.rs` files
- [x] No remaining `path = "../..."` entries in any `Cargo.toml`
- [ ] Verify `clean-room / gate` CI passes on this PR

Spec: `sovereign-stack-protected-branch-strategy.md` (Section 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)