### PR TITLE
fix: Python corpus indexing — root .md, docs/, flat layouts

### DIFF
--- a/src/cli/oracle/rag_index.rs
+++ b/src/cli/oracle/rag_index.rs
@@ -187,19 +187,31 @@ fn check_component_changed(
     existing: &std::collections::HashMap<String, oracle::rag::DocumentFingerprint>,
     extension: &str,
 ) -> bool {
-    // Check CLAUDE.md and README.md
-    if check_component_file_changed(path, "CLAUDE.md", component, config, model_hash, existing)
-        || check_component_file_changed(path, "README.md", component, config, model_hash, existing)
-    {
-        return true;
+    // Check all root-level .md files
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_file() && p.extension().is_some_and(|ext| ext == "md") {
+                let fname = p.file_name().unwrap().to_string_lossy().to_string();
+                if check_component_file_changed(path, &fname, component, config, model_hash, existing) {
+                    return true;
+                }
+            }
+        }
     }
 
-    // Check src/ directory
+    // Check src/ directory, falling back to root for Python flat-layout packages
     let src_dir = path.join("src");
-    if src_dir.exists() {
-        let base = src_dir.parent().unwrap_or(&src_dir);
+    let (scan_dir, base) = if src_dir.exists() {
+        (src_dir.clone(), src_dir.parent().unwrap_or(&src_dir).to_path_buf())
+    } else if extension == "py" {
+        (path.to_path_buf(), path.to_path_buf())
+    } else {
+        (src_dir.clone(), path.to_path_buf())
+    };
+    if scan_dir.exists() {
         if check_dir_for_changes(
-            &src_dir, base, component, config, model_hash, existing, extension,
+            &scan_dir, &base, component, config, model_hash, existing, extension,
         ) {
             return true;
         }
@@ -794,8 +806,8 @@ fn run_index_phases(
         &config.python_chunker_config,
         config.model_hash,
         "py",
-        false,
-        false,
+        true,
+        true,
         reindexer,
         indexer,
         indexed_count,

--- a/src/cli/oracle_indexing.rs
+++ b/src/cli/oracle_indexing.rs
@@ -210,54 +210,54 @@ pub(crate) fn index_component(
     fingerprints: &mut std::collections::HashMap<String, oracle::rag::DocumentFingerprint>,
     chunk_contents: &mut std::collections::HashMap<String, String>,
 ) {
-    // Index CLAUDE.md (P0)
-    let claude_md = path.join("CLAUDE.md");
-    if claude_md.exists() {
-        let doc_id = format!("{}/CLAUDE.md", component);
-        index_doc_file(
-            &claude_md,
-            &doc_id,
-            &doc_id,
-            chunker,
-            chunker_config,
-            model_hash,
-            reindexer,
-            indexer,
-            indexed_count,
-            total_chunks,
-            fingerprints,
-            chunk_contents,
-        );
-    }
-
-    // Index README.md (P1)
-    let readme_md = path.join("README.md");
-    if readme_md.exists() {
-        let doc_id = format!("{}/README.md", component);
-        index_doc_file(
-            &readme_md,
-            &doc_id,
-            &doc_id,
-            chunker,
-            chunker_config,
-            model_hash,
-            reindexer,
-            indexer,
-            indexed_count,
-            total_chunks,
-            fingerprints,
-            chunk_contents,
-        );
+    // Index all root-level .md files (CLAUDE.md, README.md, CONTRIBUTING.md, etc.)
+    if let Ok(entries) = std::fs::read_dir(path) {
+        let mut md_files: Vec<_> = entries
+            .flatten()
+            .filter(|e| {
+                e.path().extension().is_some_and(|ext| ext == "md") && e.path().is_file()
+            })
+            .collect();
+        // Sort for deterministic indexing order (CLAUDE.md first if present)
+        md_files.sort_by_key(|e| e.file_name());
+        for entry in md_files {
+            let md_path = entry.path();
+            let file_name = md_path.file_name().unwrap().to_string_lossy();
+            let doc_id = format!("{}/{}", component, file_name);
+            index_doc_file(
+                &md_path,
+                &doc_id,
+                &doc_id,
+                chunker,
+                chunker_config,
+                model_hash,
+                reindexer,
+                indexer,
+                indexed_count,
+                total_chunks,
+                fingerprints,
+                chunk_contents,
+            );
+        }
     }
 
     // Index source files (P2)
     let src_dir = path.join("src");
-    if src_dir.exists() {
-        let base = src_dir.parent().unwrap_or(&src_dir);
+    let (scan_dir, base) = if src_dir.exists() {
+        (src_dir.clone(), src_dir.parent().unwrap_or(&src_dir).to_path_buf())
+    } else if extension == "py" {
+        // Python packages often use flat layouts (e.g. databricks/, mypackage/)
+        // instead of src/. Fall back to scanning the root directory.
+        (path.to_path_buf(), path.to_path_buf())
+    } else {
+        // Rust always uses src/
+        (src_dir.clone(), path.to_path_buf())
+    };
+    if scan_dir.exists() {
         match extension {
             "rs" => index_rust_files(
-                &src_dir,
-                base,
+                &scan_dir,
+                &base,
                 component,
                 chunker,
                 chunker_config,
@@ -270,8 +270,8 @@ pub(crate) fn index_component(
                 chunk_contents,
             ),
             "py" => index_python_files(
-                &src_dir,
-                base,
+                &scan_dir,
+                &base,
                 component,
                 chunker,
                 chunker_config,


### PR DESCRIPTION
## Summary
- **#26**: Index all root-level `.md` files (CONTRIBUTING.md, CHANGELOG.md, etc.), not just CLAUDE.md and README.md
- **#27**: Enable `include_specs` and `include_book` for Python corpora — was hardcoded `false`, now `true` (matches Rust behavior)
- **#28**: Fall back to scanning root directory when `src/` doesn't exist — Python flat-layout packages (e.g. `databricks/sdk/`) now indexed instead of silently skipped

Also fixes `check_component_changed` for cache invalidation consistency.

Fixes #26, #27, #28

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --lib` — 5645 passed, 0 failed
- [ ] Index a Python corpus with flat layout (no `src/`) — verify .py files indexed
- [ ] Index a repo with CONTRIBUTING.md — verify it appears in index

🤖 Generated with [Claude Code](https://claude.com/claude-code)