### PR TITLE
fix: add probar sibling checkout to nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,6 +78,21 @@ jobs:
         shell: pwsh
         run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\provable-contracts" -Target "$env:GITHUB_WORKSPACE\provable-contracts" -Force
 
+      - name: Checkout probar (path dep)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          repository: paiml/probar
+          path: probar
+
+      - name: Symlink probar for Cargo path deps
+        if: runner.os != 'Windows'
+        run: ln -sf "$GITHUB_WORKSPACE/probar" "$GITHUB_WORKSPACE/../probar"
+
+      - name: Symlink probar (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\probar" -Target "$env:GITHUB_WORKSPACE\probar" -Force
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- Nightly builds fail because `jugar-probar = { version = "1.0", path = "../probar/crates/probar" }` requires the probar sibling directory to exist
- Adds checkout + symlink steps for `paiml/probar`, mirroring the existing `provable-contracts` pattern
- Covers Linux, macOS (symlink) and Windows (junction)

## Test plan
- [ ] Trigger manual `workflow_dispatch` on nightly after merge
- [ ] Verify all 4 targets build successfully (x86_64-linux, x86_64-macos, aarch64-macos, x86_64-windows)

Refs batuta#87

🤖 Generated with [Claude Code](https://claude.com/claude-code)